### PR TITLE
Drop SLH-DSA-SHA2-128f; register a symmetric pair at Category 1, 'small'

### DIFF
--- a/draft-ietf-cose-sphincs-plus.md
+++ b/draft-ietf-cose-sphincs-plus.md
@@ -117,7 +117,7 @@ This document introduces the registration of the following algorithms in {{-IANA
 {{FIPS-205}} defines twelve parameter sets in total, across three NIST
 security categories (1, 3, 5), two hash function families (SHA2 and SHAKE),
 and two size/speed tradeoffs (small `s` and fast `f`). This document
-registers only the two NIST Category 1, "small" parameter sets — one for
+registers only the two NIST Category 1, "small" parameter sets - one for
 each hash function family. Limiting the initial registration to a small,
 symmetric set is intended to maximize interoperability among early
 implementations and to keep the JOSE and COSE registries focused.

--- a/draft-ietf-cose-sphincs-plus.md
+++ b/draft-ietf-cose-sphincs-plus.md
@@ -104,7 +104,6 @@ This document introduces the registration of the following algorithms in {{-IANA
 |-------------|------|-------------|
 | SLH-DSA-SHA2-128s  | SLH-DSA-SHA2-128s     | JSON Web Signature Algorithm for SLH-DSA-SHA2-128s |
 | SLH-DSA-SHAKE-128s | SLH-DSA-SHAKE-128s    | JSON Web Signature Algorithm for SLH-DSA-SHAKE-128s |
-| SLH-DSA-SHA2-128f  | SLH-DSA-SHA2-128f     | JSON Web Signature Algorithm for SLH-DSA-SHA2-128f |
 {: #jose-algorithms align="left" title="JOSE Algorithms for SLH-DSA"}
 
 This document introduces the registration of the following algorithms in {{-IANA.cose}}:
@@ -113,8 +112,19 @@ This document introduces the registration of the following algorithms in {{-IANA
 |-------------|------|-------------|
 | SLH-DSA-SHA2-128s  | TBD1 (-51) | CBOR Object Signing Algorithm for SLH-DSA-SHA2-128s |
 | SLH-DSA-SHAKE-128s | TBD2 (-52) | CBOR Object Signing Algorithm for SLH-DSA-SHAKE-128s |
-| SLH-DSA-SHA2-128f  | TBD3 (-53) | CBOR Object Signing Algorithm for SLH-DSA-SHA2-128f |
 {: #cose-algorithms align="left" title="COSE Algorithms for SLH-DSA"}
+
+{{FIPS-205}} defines twelve parameter sets in total, across three NIST
+security categories (1, 3, 5), two hash function families (SHA2 and SHAKE),
+and two size/speed tradeoffs (small `s` and fast `f`). This document
+registers only the two NIST Category 1, "small" parameter sets — one for
+each hash function family. Limiting the initial registration to a small,
+symmetric set is intended to maximize interoperability among early
+implementations and to keep the JOSE and COSE registries focused.
+
+Future documents may register additional SLH-DSA parameter sets — including
+higher security categories or the "fast" variants — as deployment
+experience identifies the need.
 
 # SLH-DSA Keys
 
@@ -122,7 +132,7 @@ Private and public keys are produced to enable the sign and verify operations fo
 
 The SLH-DSA Algorithm Family uses the Algorithm Key Pair (AKP) key type, as defined in {{-ML-DSA}}. This ensures compatibility across different cryptographic algorithms that use AKP for key representation.
 
-The specific algorithms for SLH-DSA, such as SLH-DSA-SHA2-128s, SLH-DSA-SHAKE-128s, and SLH-DSA-SHA2-128f, are defined in this document and are used in the `alg` value of an AKP key representation to specify the corresponding algorithm.
+The specific algorithms for SLH-DSA, namely SLH-DSA-SHA2-128s and SLH-DSA-SHAKE-128s, are defined in this document and are used in the `alg` value of an AKP key representation to specify the corresponding algorithm.
 
 Thumbprints for SLH-DSA keys are computed according to the process described in {{-ML-DSA}}.
 
@@ -215,16 +225,6 @@ The following registration templates are provided in accordance with the procedu
 * Reference: RFC XXXX
 * Recommended: Yes
 
-### SLH-DSA-SHA2-128f
-
-* Name: SLH-DSA-SHA2-128f
-* Value: TBD3 (requested assignment -53)
-* Description: CBOR Object Signing Algorithm for SLH-DSA-SHA2-128f
-* Capabilities: `[kty]`
-* Change Controller: IETF
-* Reference: RFC XXXX
-* Recommended: Yes
-
 ## New JOSE Algorithms
 
 IANA is requested to add the following entries to the JSON Web Signature and Encryption Algorithms Registry.
@@ -245,16 +245,6 @@ The following completed registration templates are provided as described in {{-J
 
 * Algorithm Name: SLH-DSA-SHAKE-128s
 * Algorithm Description: SLH-DSA-SHAKE-128s as described in FIPS 205.
-* Algorithm Usage Location(s): alg
-* JOSE Implementation Requirements: Optional
-* Change Controller: IETF
-* Specification Document(s): RFC XXXX
-* Algorithm Analysis Documents(s): {{FIPS-205}}
-
-### SLH-DSA-SHA2-128f
-
-* Algorithm Name: SLH-DSA-SHA2-128f
-* Algorithm Description: SLH-DSA-SHA2-128f as described in FIPS 205.
 * Algorithm Usage Location(s): alg
 * JOSE Implementation Requirements: Optional
 * Change Controller: IETF
@@ -295,18 +285,6 @@ Source code is available in the `examples/` directory.
 ~~~
 {: #SLH-DSA-SHAKE-128s-public-jwk title="Example SLH-DSA-SHAKE-128s Public JSON Web Key"}
 
-### SLH-DSA-SHA2-128f
-
-~~~json
-{::include testvectors/SLH-DSA-SHA2-128f/private-jwk.json}
-~~~
-{: #SLH-DSA-SHA2-128f-private-jwk title="Example SLH-DSA-SHA2-128f Private JSON Web Key"}
-
-~~~json
-{::include testvectors/SLH-DSA-SHA2-128f/public-jwk.json}
-~~~
-{: #SLH-DSA-SHA2-128f-public-jwk title="Example SLH-DSA-SHA2-128f Public JSON Web Key"}
-
 ## COSE
 
 ### SLH-DSA-SHA2-128s
@@ -332,18 +310,6 @@ Source code is available in the `examples/` directory.
 {::include testvectors/SLH-DSA-SHAKE-128s/cose-sign1.diag}
 ~~~~
 {: #SLH-DSA-SHAKE-128s-cose-sign1 title="Example SLH-DSA-SHAKE-128s COSE Sign1"}
-
-### SLH-DSA-SHA2-128f
-
-~~~~ cbor-diag
-{::include testvectors/SLH-DSA-SHA2-128f/cose-key.diag}
-~~~~
-{: #SLH-DSA-SHA2-128f-private-cose-key title="Example SLH-DSA-SHA2-128f COSE Key"}
-
-~~~~ cbor-diag
-{::include testvectors/SLH-DSA-SHA2-128f/cose-sign1.diag}
-~~~~
-{: #SLH-DSA-SHA2-128f-cose-sign1 title="Example SLH-DSA-SHA2-128f COSE Sign1"}
 
 # Acknowledgments
 {:numbered="false"}


### PR DESCRIPTION
## Summary

Reduce the initial algorithm registration from three FIPS-205 parameter sets (SLH-DSA-SHA2-128s, SLH-DSA-SHAKE-128s, SLH-DSA-SHA2-128f) to a symmetric pair: **SLH-DSA-SHA2-128s and SLH-DSA-SHAKE-128s** — one entry per hash function family at NIST Category 1, "small".

This responds to [Simo Sorce's JOSE-list feedback](https://mailarchive.ietf.org/arch/msg/jose/TTTGCE8cAPSrkC28Sl-oAbeLBWs/), where he flagged that "3 were selected is curious and requires explanation" and suggested either 2 (the 128s pair) or 4 (a full s+f matrix). This PR takes the 2-algorithm option.

### Why drop algorithms instead of adding more

Registering fewer algorithms improves interoperability among early implementations and keeps the JOSE and COSE algorithm registries focused. The previous three-algorithm set was asymmetric — two "small" variants plus a single "fast" variant in only the SHA2 family — which is hard to defend on either size or hash-family grounds.

### Future extensibility

The draft now states explicitly that **future documents may register additional FIPS-205 parameter sets** (higher NIST security categories 3 and 5, the "fast" variants in either hash family, or HashSLH-DSA) as deployment experience identifies the need. Nothing about the AKP key type or the structural choices in this document precludes those follow-on registrations.

## Changes

- Remove SLH-DSA-SHA2-128f from the JOSE and COSE algorithm tables.
- Remove the SLH-DSA-SHA2-128f IANA registration templates (JOSE and COSE).
- Remove the SLH-DSA-SHA2-128f JWK and COSE_Key examples.
- Add a paragraph in "The SLH-DSA Algorithm Family" explaining the scoping rationale and the path for future registrations.

Simo Sorce is acknowledged in the existing Acknowledgments section.

## Test plan

- [ ] WG review: confirm 2-algorithm symmetric pair is the right initial scope.
- [ ] Confirm with the chairs that COSE alg values -51 and -52 remain (with -53 returned to the registry).
- [ ] `make` builds cleanly (passes locally).

## Note on PR ordering

This PR is intentionally separated from #15 (editorial / `ctx` / FIPS-205 terminology fixes) so the scope decision can be discussed on its own. The two PRs do not conflict and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)